### PR TITLE
Revert "Add connectivity check in NewConn."

### DIFF
--- a/kt/bench_test.go
+++ b/kt/bench_test.go
@@ -66,7 +66,7 @@ func BenchmarkGetLarge(b *testing.B) {
 func BenchmarkBulkBytes(b *testing.B) {
 	cmd := startServer(b)
 	defer haltServer(cmd, b)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 	if err != nil {
 		b.Fatal(err.Error())
 	}

--- a/kt/bench_test.go
+++ b/kt/bench_test.go
@@ -9,10 +9,7 @@ import (
 func BenchmarkSet(b *testing.B) {
 	cmd := startServer(b)
 	defer haltServer(cmd, b)
-	conn, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		b.Fatal(err.Error())
-	}
+	conn := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		str := strconv.Itoa(i)
@@ -23,10 +20,7 @@ func BenchmarkSet(b *testing.B) {
 func BenchmarkSetLarge(b *testing.B) {
 	cmd := startServer(b)
 	defer haltServer(cmd, b)
-	conn, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		b.Fatal(err.Error())
-	}
+	conn := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 	var large [4096]byte
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -38,11 +32,8 @@ func BenchmarkSetLarge(b *testing.B) {
 func BenchmarkGet(b *testing.B) {
 	cmd := startServer(b)
 	defer haltServer(cmd, b)
-	conn, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		b.Fatal(err.Error())
-	}
-	err = conn.Set("something", []byte("foobar"))
+	conn := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
+	err := conn.Set("something", []byte("foobar"))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -58,11 +49,8 @@ func BenchmarkGet(b *testing.B) {
 func BenchmarkGetLarge(b *testing.B) {
 	cmd := startServer(b)
 	defer haltServer(cmd, b)
-	conn, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		b.Fatal(err.Error())
-	}
-	err = conn.Set("something", make([]byte, 4096))
+	conn := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
+	err := conn.Set("something", make([]byte, 4096))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/kt/kt.go
+++ b/kt/kt.go
@@ -39,7 +39,7 @@ type Conn struct {
 // REST format is just the body of the HTTP request being the value.
 
 // NewConn creates a connection to an Kyoto Tycoon endpoint.
-func NewConn(host string, port int, poolsize int, timeout time.Duration) (*Conn, error) {
+func NewConn(host string, port int, poolsize int, timeout time.Duration) *Conn {
 	portstr := strconv.Itoa(port)
 	c := &Conn{
 		timeout: timeout,
@@ -50,13 +50,7 @@ func NewConn(host string, port int, poolsize int, timeout time.Duration) (*Conn,
 		},
 	}
 
-	// connectivity check so that we can bail out
-	// early instead of when we do the first operation.
-	_, _, err := c.doRPC("/rpc/void", nil)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return c
 }
 
 var (

--- a/kt/kt_base_test.go
+++ b/kt/kt_base_test.go
@@ -56,10 +56,7 @@ func TestCount(t *testing.T) {
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
 
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
 	db.Set("name", []byte("Steve Vai"))
 	if n, err := db.Count(); err != nil {
@@ -74,10 +71,7 @@ func TestGetSet(t *testing.T) {
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
 
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 	keys := []string{"a", "b", "c"}
 	for _, k := range keys {
 		db.Set(k, []byte(k))
@@ -92,10 +86,7 @@ func TestMatchPrefix(t *testing.T) {
 
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
 	keys := []string{
 		"cache/news/1",
@@ -157,10 +148,7 @@ func TestGetBulk(t *testing.T) {
 
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
 	testKeys := map[string]string{}
 	baseKeys := map[string]string{
@@ -177,7 +165,7 @@ func TestGetBulk(t *testing.T) {
 		testKeys[k] = ""
 	}
 
-	err = db.GetBulk(testKeys)
+	err := db.GetBulk(testKeys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,10 +202,7 @@ func TestSetGetRemoveBulk(t *testing.T) {
 
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
 	testKeys := map[string]string{}
 	baseKeys := map[string]string{
@@ -263,10 +248,7 @@ func TestGetBulkBytes(t *testing.T) {
 
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
 	testKeys := map[string][]byte{}
 	baseKeys := map[string][]byte{
@@ -283,7 +265,7 @@ func TestGetBulkBytes(t *testing.T) {
 		testKeys[k] = []byte("")
 	}
 
-	err = db.GetBulkBytes(testKeys)
+	err := db.GetBulkBytes(testKeys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,10 +317,7 @@ func TestGetBulkBytesLargeValue(t *testing.T) {
 
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
 	testKeys := map[string][]byte{}
 	baseKeys := map[string][]byte{
@@ -355,7 +334,7 @@ func TestGetBulkBytesLargeValue(t *testing.T) {
 		testKeys[k] = []byte("")
 	}
 
-	err = db.GetBulkBytes(testKeys)
+	err := db.GetBulkBytes(testKeys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,12 +366,9 @@ func TestGetBytes(t *testing.T) {
 
 	cmd := startServer(t)
 	defer haltServer(cmd, t)
-	db, err := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	db := NewConn(KTHOST, KTPORT, 1, DEFAULT_TIMEOUT)
 
-	_, err = db.GetBytes("//doesntexist")
+	_, err := db.GetBytes("//doesntexist")
 	if !strings.HasSuffix(err.Error(), "logical inconsistency") {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This reverts commit a0c48272518e6f39a9057a5e111cb95fc9533b6e.

Conflicts:
	kt/kt.go